### PR TITLE
feature(cordova-native): fix universalLinks and kc options

### DIFF
--- a/adapters/oidc/js/src/main/resources/keycloak.d.ts
+++ b/adapters/oidc/js/src/main/resources/keycloak.d.ts
@@ -29,7 +29,7 @@ export = Keycloak;
 declare function Keycloak(config?: string|{}): Keycloak.KeycloakInstance;
 
 declare namespace Keycloak {
-	type KeycloakAdapterName = 'cordova'|'default' | any;
+	type KeycloakAdapterName = 'cordova' | 'cordova-native' |'default' | any;
 	type KeycloakOnLoad = 'login-required'|'check-sso';
 	type KeycloakResponseMode = 'query'|'fragment';
 	type KeycloakResponseType = 'code'|'id_token token'|'code id_token token';
@@ -97,6 +97,12 @@ declare namespace Keycloak {
 		 *                   recommended over query.
 		 */
 		responseMode?: KeycloakResponseMode;
+
+		/**
+		 * Specifies a default uri to redirect to after login or logout.
+		 * This is currently supported for adapter 'cordova-native' and 'default'
+		 */
+		redirectUri?: string;
 
 		/**
 		 * Set the OpenID Connect flow.

--- a/adapters/oidc/js/src/main/resources/keycloak.js
+++ b/adapters/oidc/js/src/main/resources/keycloak.js
@@ -105,6 +105,10 @@
                 if (initOptions.timeSkew != null) {
                     kc.timeSkew = initOptions.timeSkew;
                 }
+
+                if(initOptions.redirectUri) {
+                    kc.redirectUri = initOptions.redirectUri;
+                }
             }
 
             if (!kc.responseMode) {
@@ -1355,6 +1359,7 @@
                         universalLinks.subscribe('logout', function(event) {
                             universalLinks.unsubscribe('logout');
                             window.cordova.plugins.browsertab.close();
+                            kc.authenticated = false;
                             promise.setSuccess();
                         });
 

--- a/examples/cordova-native/config.xml
+++ b/examples/cordova-native/config.xml
@@ -15,7 +15,8 @@
     <preference name="AndroidLaunchMode" value="singleTask" />
     <universal-links>
         <host name="keycloak-cordova-example.github.io" scheme="https">
-            <path event="keycloak" url="/login" />
+            <path event="login" url="/login" />
+            <path event="logout" url="/logout" />
         </host>
     </universal-links>
     <plugin name="cordova-plugin-browsertab" spec="~0.2.0" />

--- a/examples/cordova-native/www/index.html
+++ b/examples/cordova-native/www/index.html
@@ -77,7 +77,7 @@
 <div id="authenticated" style="display: none;">
     <div>
         <button onclick="keycloak.logout({ redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/logout'
- }).then(updateState)">Log out
+ })">Log out
         </button>
         <button onclick="keycloak.updateToken()">Refresh token</button>
         <button onclick="keycloak.updateToken(9999)">Force Refresh token</button>

--- a/examples/cordova-native/www/index.html
+++ b/examples/cordova-native/www/index.html
@@ -54,15 +54,13 @@
             document.getElementById('error').innerText = 'Failed to initialize Keycloak adapter';
         }
 
-        var keycloakconf = {
-            adapter: 'cordova-native',
-            responseMode: 'query',
-            onLoad: 'check-sso',
-            redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/login'
-        };
-
         document.addEventListener("deviceready", function () {
-            keycloak.init(keycloakconf).success(updateState).error(error);
+            keycloak.init({
+              adapter: 'cordova-native',
+              responseMode: 'query',
+              onLoad: 'check-sso',
+              redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/login'
+            }).success(updateState).error(error);
         }, false);
     </script>
     <style>
@@ -78,9 +76,8 @@
 <body>
 <div id="authenticated" style="display: none;">
     <div>
-        <button onclick="keycloak.logout(Object.assign(keycloakconf, {
-                redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/logout'}
-            )).then(updateState)">Log out
+        <button onclick="keycloak.logout({ redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/logout'
+ }).then(updateState)">Log out
         </button>
         <button onclick="keycloak.updateToken()">Refresh token</button>
         <button onclick="keycloak.updateToken(9999)">Force Refresh token</button>
@@ -117,7 +114,7 @@
 </div>
 <div id="not-authenticated" style="display: none;">
     <div>
-        <button onclick="keycloak.login(keycloakconf)">Log in</button>
+        <button onclick="keycloak.login()">Log in</button>
     </div>
     <div>
         <p id="error">Not authenticated</p>

--- a/examples/cordova-native/www/index.html
+++ b/examples/cordova-native/www/index.html
@@ -54,8 +54,15 @@
             document.getElementById('error').innerText = 'Failed to initialize Keycloak adapter';
         }
 
-        document.addEventListener("deviceready", function() {
-            keycloak.init({ adapter: 'cordova-native', responseMode: 'query', redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/login' }).success(updateState).error(error);
+        var keycloakconf = {
+            adapter: 'cordova-native',
+            responseMode: 'query',
+            onLoad: 'check-sso',
+            redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/login'
+        };
+
+        document.addEventListener("deviceready", function () {
+            keycloak.init(keycloakconf).success(updateState).error(error);
         }, false);
     </script>
     <style>
@@ -71,7 +78,10 @@
 <body>
 <div id="authenticated" style="display: none;">
     <div>
-        <button onclick="keycloak.logout()">Log out</button>
+        <button onclick="keycloak.logout(Object.assign(keycloakconf, {
+                redirectUri: 'android-app://org.keycloak.examples.cordova/https/keycloak-cordova-example.github.io/logout'}
+            )).then(updateState)">Log out
+        </button>
         <button onclick="keycloak.updateToken()">Refresh token</button>
         <button onclick="keycloak.updateToken(9999)">Force Refresh token</button>
         <button onclick="keycloak.accountManagement()">Manage account</button>
@@ -107,7 +117,7 @@
 </div>
 <div id="not-authenticated" style="display: none;">
     <div>
-        <button onclick="keycloak.login()">Log in</button>
+        <button onclick="keycloak.login(keycloakconf)">Log in</button>
     </div>
     <div>
         <p id="error">Not authenticated</p>


### PR DESCRIPTION
Added 'cordova-native' to typings

Added an option to define a "default" redirectUri in keycloak.js

Added 'login' and 'logout' event to universalLinks configuration in config.xml

Improved 'cordova-native' example to always use a redirectUri and
update state after successfull logout

Setting the 'authenticated' flag for the keycloak instance to 'false'
after a logout redirect